### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Visitors
 
 [![Build Status](https://travis-ci.org/twneale/visitors.svg?branch=master)](https://travis-ci.org/twneale/visitors)
 [![Coverage Status](https://coveralls.io/repos/twneale/visitors/badge.png?branch=master)](https://coveralls.io/r/twneale/visitors?branch=master)
-[![Latest Version](https://pypip.in/version/visitors/badge.png)](https://pypi.python.org/pypi/visitors/)
-[![Download Format](https://pypip.in/format/visitors/badge.png)](https://pypi.python.org/pypi/visitors/)
+[![Latest Version](https://img.shields.io/pypi/v/visitors.svg)](https://pypi.python.org/pypi/visitors/)
+[![Download Format](https://img.shields.io/pypi/format/visitors.svg)](https://pypi.python.org/pypi/visitors/)
 
 A re-usable visitor pattern implementation.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20visitors))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `visitors`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.